### PR TITLE
Don't create build dir in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu
+FROM alpine
 
 MAINTAINER Kelvin Abrokwa (kelvinabrokwa@gmail.com)
 
 # install dependencies
-RUN apt-get update && apt-get install -y \
-        build-essential \
+RUN apk add --update \
+        alpine-sdk \
         gcc-avr \
         binutils-avr \
         avr-libc
+
+WORKDIR firmware/

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(HEX): $(BINARY)
 
 docker-build:
 	docker build -t firmware-builder .
-	docker run -it -v `pwd`/:/firmware firmware-builder /bin/bash -c "cd firmware; make"
+	docker run --rm -v `pwd`/:/firmware firmware-builder make
 
 flash-arduino-uno: $(HEX)
 	avrdude -c $(PROGRAMMER) -p $(MMCU) -P $(USB) -U flash:w:$< -v

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ $(HEX): $(BINARY)
 	$(OBJCOPY) $(HEXFLAGS) $< $@
 
 docker-build:
-	mkdir -p build
 	docker build -t firmware-builder .
 	docker run -it -v `pwd`/:/firmware firmware-builder /bin/bash -c "cd firmware; make"
 


### PR DESCRIPTION
Since there is only one build artifact (the `.hex` file) we can just place it in the root directory

re: https://github.com/tribesat/firmware/issues/2