### PR TITLE
Switch docker base image to alpine, and remove container after compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,4 @@ RUN apk add --update \
         binutils-avr \
         avr-libc
 
-ADD . firmware/
 WORKDIR firmware/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu
+FROM alpine
 
 MAINTAINER Kelvin Abrokwa (kelvinabrokwa@gmail.com)
 
 # install dependencies
-RUN apt-get update && apt-get install -y \
-        build-essential \
+RUN apk add --update \
+        alpine-sdk \
         gcc-avr \
         binutils-avr \
         avr-libc
+
+ADD . firmware/
+WORKDIR firmware/

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(HEX): $(BINARY)
 
 docker-build:
 	docker build -t firmware-builder .
-	docker run --rm -v `pwd`/:/firmware firmware-builder /bin/sh -c "make"
+	docker run --rm -v `pwd`/:/firmware firmware-builder make
 
 flash-arduino-uno: $(HEX)
 	avrdude -c $(PROGRAMMER) -p $(MMCU) -P $(USB) -U flash:w:$< -v

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(HEX): $(BINARY)
 
 docker-build:
 	docker build -t firmware-builder .
-	docker run -it -v `pwd`/:/firmware firmware-builder /bin/bash -c "cd firmware; make"
+	docker run --rm -v `pwd`/:/firmware firmware-builder /bin/sh -c "make"
 
 flash-arduino-uno: $(HEX)
 	avrdude -c $(PROGRAMMER) -p $(MMCU) -P $(USB) -U flash:w:$< -v


### PR DESCRIPTION
I think removing the build directory is fine. I wanted to make a few other minor changes to the Dockerfile and Makefile and hope you don't mind.

Specifically, I
- changed to alpine to reduce the image size by about 100mb
- remove containers after compiling to prevent an excess amount of unused containers from building up on our machines while developing